### PR TITLE
Fix static function, need to return Eloquent\Builder but returned Model

### DIFF
--- a/src/Hashidable.php
+++ b/src/Hashidable.php
@@ -34,13 +34,14 @@ trait Hashidable
      * Finds a model by the hashid or fails
      *
      * @param string $hash
-     * @return \Illuminate\Database\Eloquent\Model
+     * @param string $columnId By default 'id' but can be diferent some developers
+     * @return \Illuminate\Database\Eloquent\Builder
      */
-    public static function whereHashid(string $hash)
+    public static function whereHashid(string $hash, string $columnId = 'id')
     {
         $static = new static();
 
-        return $static->where($static->hashidableEncoder()->decode($hash));
+        return $static->where($columnId, $static->hashidableEncoder()->decode($hash));
     }
 
     /**


### PR DESCRIPTION
When  i wanted to use **Kayandra\Hashidable** in _eloquent builder_, throw me an error that return wrong type

` User::whereHashid($userId)->where('is_public', true)->first()`
 
 So i went through the code where error throws and i saw this **wrong type.**