### PR TITLE
Set as a scope

### DIFF
--- a/src/Hashidable.php
+++ b/src/Hashidable.php
@@ -37,7 +37,7 @@ trait Hashidable
      * @param string $columnId By default 'id' but can be diferent some developers
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public static function whereHashid(string $hash, string $columnId = 'id')
+    public static function scopeWhereHashid(string $hash, string $columnId = 'id')
     {
         $static = new static();
 


### PR DESCRIPTION
Laravel throws "invalid hash_id column" because it doesn't detect as a query builder, so we need to set it as a scope